### PR TITLE
Crow execute fix

### DIFF
--- a/cyrene.lua
+++ b/cyrene.lua
@@ -72,8 +72,8 @@
 -- and Step, by @jah
 --
 --
--- v1.6.1 @21echoes
-local current_version = "1.6.1"
+-- v1.6.2 @21echoes
+local current_version = "1.6.2"
 
 engine.name = 'Ack'
 

--- a/lib/crow_io.lua
+++ b/lib/crow_io.lua
@@ -98,7 +98,7 @@ function CrowIO:gate_on(track)
   elseif type == 3 then
     c.output[track].action = "pulse(0.25, 5, 1)"
   end
-  c.output[track].execute()
+  c.output[track]()
 end
 
 function CrowIO:num_outs()


### PR DESCRIPTION
`c.output[track].execute()` -> `c.output[track]()` in the latest crow