### PR TITLE
Transport start faster

### DIFF
--- a/cyrene.lua
+++ b/cyrene.lua
@@ -72,8 +72,8 @@
 -- and Step, by @jah
 --
 --
--- v1.7.1 @21echoes
-local current_version = "1.7.1"
+-- v1.7.2 @21echoes
+local current_version = "1.7.2"
 
 engine.name = 'Ack'
 

--- a/lib/sequencer.lua
+++ b/lib/sequencer.lua
@@ -124,6 +124,8 @@ function Sequencer:start()
   if self._clock_id ~= nil then
     clock.cancel(self._clock_id)
   end
+  -- run the non-sync() innards of _clock_tick before running _clock_tick
+  self:tick()
   self._clock_id = clock.run(self._clock_tick, self)
 end
 


### PR DESCRIPTION
A `clock.transport.start()` message should be taken as an in-tempo signal to start playback immediately, don't wait for the _next_ tick